### PR TITLE
add b9 screencasts

### DIFF
--- a/content/02-quickstart/quickstart-cdd.mdx
+++ b/content/02-quickstart/quickstart-cdd.mdx
@@ -5,6 +5,11 @@ slug: /quickstart/verification-with-cdd
 ---
 
 import HighlightBox from "../../src/components/HighlightBox"
+import YoutubePlayer from "../../src/components/YoutubePlayer"
+
+<YoutubePlayer videoId="Ob7eSg9YIRI"/>
+
+## Customer Due Diligence (CDD)
 
 Every Polymesh account must pass a **minimal identity verification** before the account is permitted to transact with regulated securities on the network. This minimal verification is called **customer due diligence (CDD)**.
 

--- a/content/02-quickstart/quickstart-polyx.mdx
+++ b/content/02-quickstart/quickstart-polyx.mdx
@@ -7,7 +7,9 @@ slug: /quickstart/quickstart-polyx
 import HighlightBox from "../../src/components/HighlightBox"
 import YoutubePlayer from "../../src/components/YoutubePlayer"
 
-<YoutubePlayer videoId="zZetUxboCSI"/>
+<YoutubePlayer videoId="K-yRsA3Vts0"/>
+
+## POLYX
 
 **POLYX** is the network transaction fees token as well as the governance token that helps with decentralised network management.
 

--- a/content/02-quickstart/quickstart-wallet.mdx
+++ b/content/02-quickstart/quickstart-wallet.mdx
@@ -5,10 +5,13 @@ slug: /quickstart/wallet
 ---
 
 import HighlightBox from "../../src/components/HighlightBox"
+import YoutubePlayer from "../../src/components/YoutubePlayer"
 
-The **Polymesh Wallet** is a **Google Chrome extension** that holds local copies of account information and confidential signing keys. It enables your browser to interact with the Polymesh network.
+<YoutubePlayer videoId="Aj3jQrbfGy8"/>
 
 ## Get the Wallet
+
+The **Polymesh Wallet** is a **Google Chrome extension** that holds local copies of account information and confidential signing keys. It enables your browser to interact with the Polymesh network.
 
 Get the Polymesh Wallet extension for Google Chrome by opening Chrome's extensions panel and searching for Polymesh. You should see the card when it is installed. Be sure it is enabled.
 

--- a/content/03-originate/landingpage.mdx
+++ b/content/03-originate/landingpage.mdx
@@ -7,6 +7,9 @@ slug: /originate/creating-asset
 import OverviewBox from "../../src/components/OverviewBox"
 import ActionCard from "../../src/components/ActionCard"
 import ActionCardWrapper from "../../src/components/ActionCardWrapper"
+import YoutubePlayer from "../../src/components/YoutubePlayer"
+
+<YoutubePlayer videoId="TGDBulqZUM0"/>
 
 Learn how assets (regulated security tokens) are designed and created in Polymesh.
 

--- a/content/03-originate/originate-dashboard.mdx
+++ b/content/03-originate/originate-dashboard.mdx
@@ -7,7 +7,7 @@ slug: /originate/dashboard
 import HighlightBox from "../../src/components/HighlightBox"
 import YoutubePlayer from "../../src/components/YoutubePlayer"
 
-<YoutubePlayer videoId="TGDBulqZUM0"/>
+<YoutubePlayer videoId="H28V8nf5av8"/>
 
 
 ## Exercise

--- a/content/03-originate/secondary-keys.mdx
+++ b/content/03-originate/secondary-keys.mdx
@@ -5,6 +5,9 @@ slug: /originate/secondary-keys
 ---
 
 import HighlightBox from "../../src/components/HighlightBox"
+import YoutubePlayer from "../../src/components/YoutubePlayer"
+
+<YoutubePlayer videoId="FeUROeXrl_M"/>
 
 ## ACME Corporation
 

--- a/content/04-distribute/distribute-dashboard.mdx
+++ b/content/04-distribute/distribute-dashboard.mdx
@@ -5,6 +5,9 @@ slug: /distribute/token-dashboard
 ---
 
 import HighlightBox from "../../src/components/HighlightBox"
+import YoutubePlayer from "../../src/components/YoutubePlayer"
+
+<YoutubePlayer videoId="OC_nwMSfoHw"/>'
 
 ## Exercise
 

--- a/content/06-settlement/settlement-dashboard.mdx
+++ b/content/06-settlement/settlement-dashboard.mdx
@@ -5,6 +5,9 @@ slug: /settlement/app-portal
 ---
 
 import HighlightBox from "../../src/components/HighlightBox"
+import YoutubePlayer from "../../src/components/YoutubePlayer"
+
+<YoutubePlayer videoId="UIvoAc_MbA8"/>'
 
 ## Use case
 


### PR DESCRIPTION
Removes one Polymath vid about token studio dashboard that was redundant and less synced with the new content. 