### PR TITLE
quiz correction hotfix

### DIFF
--- a/content/05-actions/actions-quiz.mdx
+++ b/content/05-actions/actions-quiz.mdx
@@ -6,6 +6,6 @@ slug: /actions/actions-quiz
 
 import H5PContainer from "../../src/components/H5PContainer"
 
-<H5PContainer locations={["/h5p/quiz5"]}>
+<H5PContainer locations={["/h5p/quiz6"]}>
 
 </H5PContainer>

--- a/content/06-settlement/settlement-quiz.mdx
+++ b/content/06-settlement/settlement-quiz.mdx
@@ -6,6 +6,6 @@ slug: /settlement/settlement-quiz
 
 import H5PContainer from "../../src/components/H5PContainer"
 
-<H5PContainer locations={["/h5p/quiz6"]}>
+<H5PContainer locations={["/h5p/quiz5"]}>
 
 </H5PContainer>


### PR DESCRIPTION
this hotfix fixes the quiz questions. Earlier, quiz questions of settlement were appearing in corporate actions, and vice versa. in this update, the quiz references have been swapped so that the right quizes appear in the right pages.﻿
